### PR TITLE
fix saving byte strings

### DIFF
--- a/src/main/java/com/itextpdf/rups/view/contextmenu/SaveToFilePdfTreeAction.java
+++ b/src/main/java/com/itextpdf/rups/view/contextmenu/SaveToFilePdfTreeAction.java
@@ -44,6 +44,7 @@ package com.itextpdf.rups.view.contextmenu;
 
 import com.itextpdf.kernel.pdf.PdfObject;
 import com.itextpdf.kernel.pdf.PdfStream;
+import com.itextpdf.kernel.pdf.PdfString;
 import com.itextpdf.rups.model.LoggerHelper;
 import com.itextpdf.rups.model.LoggerMessages;
 import com.itextpdf.rups.view.itext.PdfTree;
@@ -105,11 +106,17 @@ public class SaveToFilePdfTreeAction extends AbstractRupsAction {
             TreePath[] paths = selectionModel.getSelectionPaths();
             PdfObjectTreeNode lastPath = (PdfObjectTreeNode) paths[0].getLastPathComponent();
             PdfObject object = lastPath.getPdfObject();
-            PdfStream stream = (PdfStream) object;
+            
+            byte array[] = null;
+            if (object instanceof PdfStream) {
+                array = ((PdfStream) object).getBytes(!saveRawBytes);
+            }
+            else if (object instanceof PdfString) {
+            	array = ((PdfString) object).getValueBytes();
+            }
 
             // get the bytes and write away
             try {
-                byte[] array = stream.getBytes(!saveRawBytes);
                 try (FileOutputStream fos = new FileOutputStream(path)) {
                     fos.write(array);
                 }


### PR DESCRIPTION
Test Case file: [blank.pdf](https://github.com/itext/i7j-rups/files/5648853/blank.pdf): Page contains ID element
 
Test Case:
 1. open blank.pdf
 2. navigate to Page
 3. right-click ID -> "Save raw bytes to file"

Expected: file will contain decoded binary data
Observed behavior with 7.1.13: file not written

This pull request creates the expected behavior.