### PR TITLE
Allow for non-javax look and feel class name

### DIFF
--- a/src/test/java/com/itextpdf/rups/RupsConfigurationTest.java
+++ b/src/test/java/com/itextpdf/rups/RupsConfigurationTest.java
@@ -119,7 +119,7 @@ public class RupsConfigurationTest {
         RupsConfiguration.INSTANCE.setLookAndFeel(laf);
         RupsConfiguration.INSTANCE.saveConfiguration();
         String lookAndFeel = RupsConfiguration.INSTANCE.getLookAndFeel();
-        Assertions.assertTrue(lookAndFeel.contains("javax.swing.plaf"));
+        Assertions.assertTrue(lookAndFeel.contains("javax.swing.plaf") || lookAndFeel.contains("java.swing.plaf"));
     }
 
     @Test
@@ -128,7 +128,9 @@ public class RupsConfigurationTest {
         RupsConfiguration.INSTANCE.setLookAndFeel(laf);
         RupsConfiguration.INSTANCE.saveConfiguration();
         String lookAndFeel = RupsConfiguration.INSTANCE.getLookAndFeel();
-        Assertions.assertTrue(lookAndFeel.contains("javax.swing.plaf") || lookAndFeel.equals("com.sun.java.swing.plaf.windows.WindowsLookAndFeel"));
+        Assertions.assertTrue(lookAndFeel.contains("javax.swing.plaf")
+            || lookAndFeel.contains("java.swing.plaf")
+            || lookAndFeel.equals("com.sun.java.swing.plaf.windows.WindowsLookAndFeel"));
     }
 
     @Test


### PR DESCRIPTION
Couldn't get it to build on my Linux system.
My laf is com.sun.java.swing.plaf.gtk.GTKLookAndFeel
