### PR TITLE
Minimal example adding line numbers to the Stream View

### DIFF
--- a/src/main/java/com/itextpdf/rups/view/itext/contentstream/LineManager.java
+++ b/src/main/java/com/itextpdf/rups/view/itext/contentstream/LineManager.java
@@ -1,0 +1,75 @@
+package com.itextpdf.rups.view.itext.contentstream;
+
+/*
+ * 
+ * A class to track the line number in a content stream
+ * 
+ */
+
+public class LineManager {
+   
+    private int lineNumber;
+    private boolean numberLines;
+    private int margin;
+    
+    {
+        lineNumber = 0;
+        margin = 10;
+    }
+
+     /**
+     * Create a LineManager with lineNumber = 0, margin = 10, numberLines = true
+     */
+    public LineManager() {
+        numberLines = true; 
+    }
+
+     /**
+     * Create a LineManager allowing for switching off the printing (hack to pass tests)
+     *
+     * @param numLines boolean indicating whether to print line numbers
+     */
+    public LineManager(boolean numLines){
+        numberLines = numLines;
+    }
+
+    /**
+     * Get the current lineNumber as a padded string of length this.margin.
+     *
+     * @return the padded string
+     */
+    public String getLineNumberString(){
+
+        if (numberLines) {
+            return pad(String.valueOf(lineNumber));
+        } else {
+            return "";
+        }
+    }
+
+    /**
+     * Increase line number by 1
+     */
+    public void increaseLineNumber(){
+        lineNumber++;
+    }
+
+    /**
+     * Reset line number to zero.
+     */
+    public void reset() {
+        lineNumber = 0;
+    }
+
+    /**
+     * Get the current lineNumber as a padded string of length this.margin.
+     *
+     * @param str a line number string to be padded
+     * @return the padded string
+     */
+    private String pad(String str) {
+
+        return str + " ".repeat(margin - str.length());        
+
+    }
+}

--- a/src/test/java/com/itextpdf/rups/view/itext/contentstream/StyledSyntaxDocumentTest.java
+++ b/src/test/java/com/itextpdf/rups/view/itext/contentstream/StyledSyntaxDocumentTest.java
@@ -633,4 +633,20 @@ public class StyledSyntaxDocumentTest {
         String expectedResult = Files.readString(Paths.get(SRC_DIR, expectedOutputFile), StandardCharsets.ISO_8859_1);
         Assertions.assertEquals(expectedResult, output);
     }
+
+    @ParameterizedTest
+    @CsvSource({
+            "baseline.cmp, baselineIndentedNumbered.cmp",
+    })
+    void testNumbering(String inputFile, String expectedOutputFile) throws Exception {
+        byte[] origBytes = Files.readAllBytes(Paths.get(SRC_DIR, inputFile));
+        StyledSyntaxDocument doc = new StyledSyntaxDocument();
+        doc.processContentStream(origBytes);
+
+        String output = doc.getText(0, doc.getLength());
+        String expectedResult = Files.readString(Paths.get(SRC_DIR, expectedOutputFile), StandardCharsets.ISO_8859_1);
+        Assertions.assertEquals(expectedResult, output);
+    }
+
+
 }

--- a/src/test/java/com/itextpdf/rups/view/itext/contentstream/StyledSyntaxDocumentTest.java
+++ b/src/test/java/com/itextpdf/rups/view/itext/contentstream/StyledSyntaxDocumentTest.java
@@ -115,7 +115,7 @@ public class StyledSyntaxDocumentTest {
     @Test
     public void testReplaceUtf8InDocument() throws Exception {
         byte[] origBytes = Files.readAllBytes(Paths.get(SRC_DIR, "utf8.cmp"));
-        StyledSyntaxDocument doc = new StyledSyntaxDocument();
+        StyledSyntaxDocument doc = new StyledSyntaxDocument(false);
         doc.processContentStream(origBytes);
 
         String theText = doc.getText(0, doc.getLength());
@@ -132,7 +132,7 @@ public class StyledSyntaxDocumentTest {
     @Test
     public void testDeleteAndInsertUtf8InDocument() throws Exception {
         byte[] origBytes = Files.readAllBytes(Paths.get(SRC_DIR, "utf8.cmp"));
-        StyledSyntaxDocument doc = new StyledSyntaxDocument();
+        StyledSyntaxDocument doc = new StyledSyntaxDocument(false);
         doc.processContentStream(origBytes);
 
         String theText = doc.getText(0, doc.getLength());
@@ -167,7 +167,7 @@ public class StyledSyntaxDocumentTest {
     @Test
     public void testInlineImageDocContainsPlaceholderWhitespace() throws Exception {
         byte[] origBytes = Files.readAllBytes(Paths.get(SRC_DIR, "charprocWithInlineImg.cmp"));
-        StyledSyntaxDocument doc = new StyledSyntaxDocument();
+        StyledSyntaxDocument doc = new StyledSyntaxDocument(false);
         doc.processContentStream(origBytes);
 
         String theText = doc.getText(0, doc.getLength());
@@ -190,7 +190,7 @@ public class StyledSyntaxDocumentTest {
     @Test
     public void testBinaryStringDoesNotPermitNonHexReplacement() throws Exception {
         byte[] origBytes = Files.readAllBytes(Paths.get(SRC_DIR, "stringWithBin.cmp"));
-        StyledSyntaxDocument doc = new StyledSyntaxDocument();
+        StyledSyntaxDocument doc = new StyledSyntaxDocument(false);
         doc.processContentStream(origBytes);
 
         String theText = doc.getText(0, doc.getLength());
@@ -218,7 +218,7 @@ public class StyledSyntaxDocumentTest {
     @Test
     public void testBinaryStringPermitsNullReplace() throws Exception {
         byte[] origBytes = Files.readAllBytes(Paths.get(SRC_DIR, "stringWithBin.cmp"));
-        StyledSyntaxDocument doc = new StyledSyntaxDocument();
+        StyledSyntaxDocument doc = new StyledSyntaxDocument(false);
         doc.processContentStream(origBytes);
 
         String theText = doc.getText(0, doc.getLength());
@@ -230,7 +230,7 @@ public class StyledSyntaxDocumentTest {
     @Test
     public void testBinaryStringPermitsNullInsert() throws Exception {
         byte[] origBytes = Files.readAllBytes(Paths.get(SRC_DIR, "stringWithBin.cmp"));
-        StyledSyntaxDocument doc = new StyledSyntaxDocument();
+        StyledSyntaxDocument doc = new StyledSyntaxDocument(false);
         doc.processContentStream(origBytes);
 
         String theText = doc.getText(0, doc.getLength());
@@ -242,7 +242,7 @@ public class StyledSyntaxDocumentTest {
     @Test
     public void testBinaryStringDoesNotPermitNonHexInsertion() throws Exception {
         byte[] origBytes = Files.readAllBytes(Paths.get(SRC_DIR, "stringWithBin.cmp"));
-        StyledSyntaxDocument doc = new StyledSyntaxDocument();
+        StyledSyntaxDocument doc = new StyledSyntaxDocument(false);
         doc.processContentStream(origBytes);
 
         String theText = doc.getText(0, doc.getLength());
@@ -256,7 +256,7 @@ public class StyledSyntaxDocumentTest {
     @Test
     public void testRemovalEndCannotTraverseBinaryString() throws Exception {
         byte[] origBytes = Files.readAllBytes(Paths.get(SRC_DIR, "stringWithBin.cmp"));
-        StyledSyntaxDocument doc = new StyledSyntaxDocument();
+        StyledSyntaxDocument doc = new StyledSyntaxDocument(false);
         doc.processContentStream(origBytes);
 
         String theText = doc.getText(0, doc.getLength());
@@ -268,7 +268,7 @@ public class StyledSyntaxDocumentTest {
     @Test
     public void testRemovalStartCannotTraverseBinaryString() throws Exception {
         byte[] origBytes = Files.readAllBytes(Paths.get(SRC_DIR, "stringWithBin.cmp"));
-        StyledSyntaxDocument doc = new StyledSyntaxDocument();
+        StyledSyntaxDocument doc = new StyledSyntaxDocument(false);
         doc.processContentStream(origBytes);
 
         String theText = doc.getText(0, doc.getLength());
@@ -280,7 +280,7 @@ public class StyledSyntaxDocumentTest {
     @Test
     public void testRemovalCanReplaceBinaryStringEntirely() throws Exception {
         byte[] origBytes = Files.readAllBytes(Paths.get(SRC_DIR, "stringWithBin.cmp"));
-        StyledSyntaxDocument doc = new StyledSyntaxDocument();
+        StyledSyntaxDocument doc = new StyledSyntaxDocument(false);
         doc.processContentStream(origBytes);
 
         String theText = doc.getText(0, doc.getLength());
@@ -296,7 +296,7 @@ public class StyledSyntaxDocumentTest {
     @Test
     public void testMatchingOperandsMode() throws Exception {
         byte[] origBytes = Files.readAllBytes(Paths.get(SRC_DIR, "baseline.cmp"));
-        StyledSyntaxDocument doc = new StyledSyntaxDocument();
+        StyledSyntaxDocument doc = new StyledSyntaxDocument(false);
         doc.setMatchingOperands(true);
         Assertions.assertTrue(doc.isMatchingOperands());
         doc.processContentStream(origBytes);
@@ -331,7 +331,7 @@ public class StyledSyntaxDocumentTest {
 
     @Test
     public void testBogusEIDoesNotInhibitSyntaxDoc() throws Exception {
-        StyledSyntaxDocument doc = new StyledSyntaxDocument();
+        StyledSyntaxDocument doc = new StyledSyntaxDocument(false);
         PdfObject[] bogusOps = new PdfObject[] {
                 new PdfString("This makes no sense"), new PdfLiteral("EI")
         };
@@ -353,7 +353,7 @@ public class StyledSyntaxDocumentTest {
     @Test
     public void testBinaryStringEditPaddingTolerance() throws Exception {
         byte[] origBytes = Files.readAllBytes(Paths.get(SRC_DIR, "stringWithBin.cmp"));
-        StyledSyntaxDocument doc = new StyledSyntaxDocument();
+        StyledSyntaxDocument doc = new StyledSyntaxDocument(false);
         doc.processContentStream(origBytes);
 
         String theText = doc.getText(0, doc.getLength());
@@ -371,7 +371,7 @@ public class StyledSyntaxDocumentTest {
     public void testHexeditSprawlTolerance() throws Exception {
         // this shouldn't arise in normal document editing due to the filter, but let's see how
         // our defenses hold up
-        StyledSyntaxDocument doc = new StyledSyntaxDocument();
+        StyledSyntaxDocument doc = new StyledSyntaxDocument(false);
 
         PdfObject[] splitString = new PdfObject[] {
                 new PdfString("This\000is"),
@@ -400,7 +400,7 @@ public class StyledSyntaxDocumentTest {
     public void testHexeditBoundaryTolerance() throws Exception {
         // this shouldn't arise in normal document editing due to the filter, but let's see how
         // our defenses hold up
-        StyledSyntaxDocument doc = new StyledSyntaxDocument();
+        StyledSyntaxDocument doc = new StyledSyntaxDocument(false);
 
         PdfObject[] splitString = new PdfObject[] {
                 new PdfString("This\000is\000w31rd"),
@@ -423,7 +423,7 @@ public class StyledSyntaxDocumentTest {
     @Test
     public void testBinaryStringPermitsHexReplacement() throws Exception {
         byte[] origBytes = Files.readAllBytes(Paths.get(SRC_DIR, "stringWithBin.cmp"));
-        StyledSyntaxDocument doc = new StyledSyntaxDocument();
+        StyledSyntaxDocument doc = new StyledSyntaxDocument(false);
         doc.processContentStream(origBytes);
 
         String theText = doc.getText(0, doc.getLength());
@@ -441,7 +441,7 @@ public class StyledSyntaxDocumentTest {
     @Test
     public void testBinaryStringPermitsHexInsertion() throws Exception {
         byte[] origBytes = Files.readAllBytes(Paths.get(SRC_DIR, "stringWithBin.cmp"));
-        StyledSyntaxDocument doc = new StyledSyntaxDocument();
+        StyledSyntaxDocument doc = new StyledSyntaxDocument(false);
         doc.processContentStream(origBytes);
 
         String theText = doc.getText(0, doc.getLength());
@@ -459,7 +459,7 @@ public class StyledSyntaxDocumentTest {
     @Test
     public void testBinaryStringPermitsPartialHexInsertion() throws Exception {
         byte[] origBytes = Files.readAllBytes(Paths.get(SRC_DIR, "stringWithBin.cmp"));
-        StyledSyntaxDocument doc = new StyledSyntaxDocument();
+        StyledSyntaxDocument doc = new StyledSyntaxDocument(false);
         doc.processContentStream(origBytes);
 
         String theText = doc.getText(0, doc.getLength());
@@ -477,7 +477,7 @@ public class StyledSyntaxDocumentTest {
     @Test
     public void testBinaryStringPermitsHexInsertionAtEnd() throws Exception {
         byte[] origBytes = Files.readAllBytes(Paths.get(SRC_DIR, "stringWithBin.cmp"));
-        StyledSyntaxDocument doc = new StyledSyntaxDocument();
+        StyledSyntaxDocument doc = new StyledSyntaxDocument(false);
         doc.processContentStream(origBytes);
 
         String theText = doc.getText(0, doc.getLength());
@@ -495,7 +495,7 @@ public class StyledSyntaxDocumentTest {
     @Test
     public void testInlineImageDoesNotPermitInsertion() throws Exception {
         byte[] origBytes = Files.readAllBytes(Paths.get(SRC_DIR, "charprocWithInlineImg.cmp"));
-        StyledSyntaxDocument doc = new StyledSyntaxDocument();
+        StyledSyntaxDocument doc = new StyledSyntaxDocument(false);
         doc.processContentStream(origBytes);
 
         String theText = doc.getText(0, doc.getLength());
@@ -507,7 +507,7 @@ public class StyledSyntaxDocumentTest {
     @Test
     public void testInlineImageDoesNotPermitInnerRemoval() throws Exception {
         byte[] origBytes = Files.readAllBytes(Paths.get(SRC_DIR, "charprocWithInlineImg.cmp"));
-        StyledSyntaxDocument doc = new StyledSyntaxDocument();
+        StyledSyntaxDocument doc = new StyledSyntaxDocument(false);
         doc.processContentStream(origBytes);
 
         String theText = doc.getText(0, doc.getLength());
@@ -519,7 +519,7 @@ public class StyledSyntaxDocumentTest {
     @Test
     public void testInlineImageDoesNotPermitInnerReplacement() throws Exception {
         byte[] origBytes = Files.readAllBytes(Paths.get(SRC_DIR, "charprocWithInlineImg.cmp"));
-        StyledSyntaxDocument doc = new StyledSyntaxDocument();
+        StyledSyntaxDocument doc = new StyledSyntaxDocument(false);
         doc.processContentStream(origBytes);
 
         String theText = doc.getText(0, doc.getLength());
@@ -537,7 +537,7 @@ public class StyledSyntaxDocumentTest {
 
     private void checkReserialize(String inputFile) throws Exception {
         byte[] origBytes = Files.readAllBytes(Paths.get(SRC_DIR, inputFile));
-        StyledSyntaxDocument doc = new StyledSyntaxDocument();
+        StyledSyntaxDocument doc = new StyledSyntaxDocument(false);
         doc.processContentStream(origBytes);
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -549,7 +549,7 @@ public class StyledSyntaxDocumentTest {
     private void reserializeWithCompareTarget(String src, String cmp) throws Exception {
         byte[] origBytes = Files.readAllBytes(Paths.get(SRC_DIR, src));
         byte[] expectedResult = Files.readAllBytes(Paths.get(SRC_DIR, cmp));
-        StyledSyntaxDocument doc = new StyledSyntaxDocument();
+        StyledSyntaxDocument doc = new StyledSyntaxDocument(false);
         doc.processContentStream(origBytes);
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -562,7 +562,7 @@ public class StyledSyntaxDocumentTest {
     private void checkDecodedDoc(String fname, String expectedSubstring) throws Exception {
 
         byte[] origBytes = Files.readAllBytes(Paths.get(SRC_DIR, fname));
-        StyledSyntaxDocument doc = new StyledSyntaxDocument();
+        StyledSyntaxDocument doc = new StyledSyntaxDocument(false);
         doc.processContentStream(origBytes);
 
         String theText = doc.getText(0, doc.getLength());
@@ -571,7 +571,7 @@ public class StyledSyntaxDocumentTest {
 
     private void stringRemovalCheck(String marker, int len, String expectedSub) throws Exception {
         byte[] origBytes = Files.readAllBytes(Paths.get(SRC_DIR, "stringWithBin.cmp"));
-        StyledSyntaxDocument doc = new StyledSyntaxDocument();
+        StyledSyntaxDocument doc = new StyledSyntaxDocument(false);
         doc.processContentStream(origBytes);
 
         String theText = doc.getText(0, doc.getLength());
@@ -583,7 +583,7 @@ public class StyledSyntaxDocumentTest {
     @Test
     public void testEncodingTooltip() throws Exception {
         byte[] origBytes = Files.readAllBytes(Paths.get(SRC_DIR, "utf16be.cmp"));
-        StyledSyntaxDocument doc = new StyledSyntaxDocument();
+        StyledSyntaxDocument doc = new StyledSyntaxDocument(false);
         doc.processContentStream(origBytes);
 
         int start = doc.getText(0, doc.getLength()).indexOf("こんにちは");
@@ -594,7 +594,7 @@ public class StyledSyntaxDocumentTest {
     @Test
     public void testHexTooltip() throws Exception {
         byte[] origBytes = Files.readAllBytes(Paths.get(SRC_DIR, "stringWithBin.cmp"));
-        StyledSyntaxDocument doc = new StyledSyntaxDocument();
+        StyledSyntaxDocument doc = new StyledSyntaxDocument(false);
         doc.processContentStream(origBytes);
 
 
@@ -607,7 +607,7 @@ public class StyledSyntaxDocumentTest {
     @Test
     public void testNoTooltip() throws Exception {
         byte[] origBytes = Files.readAllBytes(Paths.get(SRC_DIR, "stringWithBin.cmp"));
-        StyledSyntaxDocument doc = new StyledSyntaxDocument();
+        StyledSyntaxDocument doc = new StyledSyntaxDocument(false);
         doc.processContentStream(origBytes);
 
         int start = doc.getText(0, doc.getLength()).indexOf("Tj");
@@ -626,7 +626,7 @@ public class StyledSyntaxDocumentTest {
     })
     void testIndentation(String inputFile, String expectedOutputFile) throws Exception {
         byte[] origBytes = Files.readAllBytes(Paths.get(SRC_DIR, inputFile));
-        StyledSyntaxDocument doc = new StyledSyntaxDocument();
+        StyledSyntaxDocument doc = new StyledSyntaxDocument(false);
         doc.processContentStream(origBytes);
 
         String output = doc.getText(0, doc.getLength());

--- a/src/test/resources/com/itextpdf/rups/view/itext/contentStreamSnippets/baselineIndentedNumbered.cmp
+++ b/src/test/resources/com/itextpdf/rups/view/itext/contentStreamSnippets/baselineIndentedNumbered.cmp
@@ -1,0 +1,5 @@
+1         BT
+2             /T1 1 Tf
+3             0.12 0 0 -0.12 80 600 Tm
+4             (Hello world!) Tj
+5         ET


### PR DESCRIPTION
For ease of reference it is useful to have line numbers in the Stream view panel.

The implementation is similar to the indentation implementation in #85

Changes made: 

- Add `LineManager` class. 
- Add `appendLineNumber()` method to `StyledSyntaxDocument`.
- Tested with basic byte stream. 

Considerations: 
- To quickly enable all existing tests to pass, where the examples do not have line numbers, I overloaded the constructors for `StyledSyntaxDocument` and `LineManager` to allow for a boolean parameter `numberLines`, which toggles whether line numbers are actually printed.
- This is a simple hack to get the PoC working, but it actually may be desirable behaviour because the functionality allows something like a toggle button that allows the user to switch line numbers on/off. 


TODO: 
- [ ] Test with more complex byte streams
- [ ] Consider how flexible the implementation should be.